### PR TITLE
improved docs, less warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,12 @@ Installation
 
 #. Install or add ``django-category`` to your Python path.
 
-#. Add ``category`` to your ``INSTALLED_APPS`` setting.
-
+#. Add ``category`` and  to your ``INSTALLED_APPS`` setting.
+#. Add ``django.contrib.sites`` to your ``INSTALLED_APPS`` setting, see https://docs.djangoproject.com/en/2.0/ref/contrib/sites/
+#. Define a SITE_ID setting:
+   
+    SITE_ID = 1
+   
 #. Optional: ``django-object-tools`` provides a category tree view. See https://github.com/praekelt/django-object-tools
    for installation instructions.
 

--- a/category/models.py
+++ b/category/models.py
@@ -32,7 +32,7 @@ class Category(models.Model):
     sites = models.ManyToManyField(
         "sites.Site",
         blank=True,
-        null=True,
+        #null=True,
         help_text="Limits category scope to selected sites.",
     )
 
@@ -91,7 +91,7 @@ class Tag(models.Model):
     categories = models.ManyToManyField(
         "category.Category",
         blank=True,
-        null=True,
+        #null=True,
         help_text="Categories to which this tag belongs."
     )
 


### PR DESCRIPTION
Getting working with python 3.7 and latest django

1. remove warning WARNINGS:
category.Category.sites: (fields.W340) null has no effect on ManyToManyField.
category.Tag.categories: (fields.W340) null has no effect on ManyToManyField.
2. improving documentation adding in sites option that is needed to use.